### PR TITLE
Swap order of smart reset to be opposite

### DIFF
--- a/frontend/src/project/reducers/ProjectReducer.js
+++ b/frontend/src/project/reducers/ProjectReducer.js
@@ -51,11 +51,10 @@ export default function (state = initialState, action) {
                 stateClone.pairingBoards.reduce(function (people, pairingBoard) {
                     if (pairingBoard.exempt) return people;
 
-                    var stayingPerson = pairingBoard.people.pop()
-                    people = people.concat(pairingBoard.people);
-                    if (stayingPerson) {
-                        pairingBoard.people = [stayingPerson];
+                    while(pairingBoard.people.length > 1) {
+                        people.push(pairingBoard.people.pop())
                     }
+
                     return people;
                 }, [])
             );

--- a/frontend/test/project/reducers/ProjectReducer.spec.js
+++ b/frontend/test/project/reducers/ProjectReducer.spec.js
@@ -311,8 +311,8 @@ describe("ProjectReducer", () => {
                     id: 7,
                     people: [
                         {name: "Bubba Gump"},
-                        {name: "Hanzle"},
-                        {name: "Bob"},
+                        {name: "Gretel"},
+                        {name: "Alice"},
                         {name: "Jim"}
                     ],
                     pairingBoards: [
@@ -325,13 +325,13 @@ describe("ProjectReducer", () => {
                         {
                             name: "BOARD2",
                             people: [
-                                {name: "Gretel"}
+                                {name: "Hanzle"}
                             ]
                         },
                         {
                             name: "BOARD3",
                             people: [
-                                {name: "Alice"}
+                                {name: "Bob"}
                             ]
                         },
                         {


### PR DESCRIPTION
- This makes the smart reset leave the newest person that was
recommended to join a track instead of leaving the oldest.
- without it, using recommend pairs and smart reset together would
result in the same person carrying context indefinitely.