### PR TITLE
[#155688501] Migrate to Spring Boot 2.0GA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 plugins {
-    id "org.springframework.boot" version "1.5.9.RELEASE"
+    id 'org.springframework.boot' version '2.0.0.RELEASE'
 }
+
+apply plugin: 'java'
+apply plugin: 'io.spring.dependency-management'
+apply plugin: 'org.springframework.boot'
 
 repositories {
     mavenCentral()

--- a/scripts/update-patch-checksums.sql
+++ b/scripts/update-patch-checksums.sql
@@ -1,0 +1,3 @@
+update schema_version set checksum=-661541026 where version='1';
+update schema_version set checksum=1122774959 where version='3';
+update schema_version set checksum=531856925 where version='4';

--- a/src/main/java/com/parrit/configurations/AuthorizationService.java
+++ b/src/main/java/com/parrit/configurations/AuthorizationService.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 public class AuthorizationService {
@@ -23,7 +24,9 @@ public class AuthorizationService {
     }
 
     public boolean canAccessProject(User user, long projectId) {
-        Project project = projectRepository.findOne(projectId);
-        return project != null && canAccessProject(user, project.getName());
+        Optional<Project> project = projectRepository.findById(projectId);
+        return project
+           .filter(p -> canAccessProject(user, p.getName()))
+			  .isPresent();
     }
 }

--- a/src/main/java/com/parrit/controllers/ProjectController.java
+++ b/src/main/java/com/parrit/controllers/ProjectController.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.authentication.encoding.PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -68,7 +68,7 @@ public class ProjectController {
             throw new ProjectNameAlreadyExistsException("Not again. That name already exists, try a different one.");
         }
 
-        String hashedPassword = passwordEncoder.encodePassword(newProjectDTO.getPassword(), null);
+        String hashedPassword = passwordEncoder.encode(newProjectDTO.getPassword());
 
         List<PairingBoard> defaultPairingBoards = new ArrayList<>();
         defaultPairingBoards.add(new PairingBoard("COCKATOO", false, new ArrayList<>(), new ArrayList<>()));
@@ -86,7 +86,7 @@ public class ProjectController {
     @RequestMapping(path = "/api/project/{projectId}", method = RequestMethod.PUT)
     @ResponseBody
     public ResponseEntity<ProjectDTO> updateProject(@PathVariable long projectId, @RequestBody @Valid ProjectDTO projectDTO) {
-        Project existingProject = projectRepository.findOne(projectId);
+        Project existingProject = projectRepository.findById(projectId).orElse(Project.NULL);
 
         Project updatedProject = ProjectTransformer.merge(existingProject, projectDTO);
 
@@ -98,7 +98,7 @@ public class ProjectController {
     @RequestMapping(path = "/api/project/{projectId}/person", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity<ProjectDTO> addPerson(@PathVariable long projectId, @RequestBody @Valid PersonDTO personDTO) {
-        Project savedProject = projectRepository.findOne(projectId);
+        Project savedProject = projectRepository.findById(projectId).orElse(Project.NULL);
 
         savedProject.getPeople().add(new Person(personDTO.getName()));
 
@@ -110,7 +110,7 @@ public class ProjectController {
     @RequestMapping(path = "/api/project/{projectId}/pairingBoard/{pairingBoardId}/role", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity<ProjectDTO> addRole(@PathVariable long projectId, @PathVariable long pairingBoardId, @RequestBody @Valid RoleDTO roleDTO) {
-        Project savedProject = projectRepository.findOne(projectId);
+        Project savedProject = projectRepository.findById(projectId).orElse(Project.NULL);
 
         PairingBoard matchingPairingBoard = savedProject.getPairingBoards().stream()
                 .filter(pb -> pb.getId() == pairingBoardId)
@@ -127,7 +127,7 @@ public class ProjectController {
     @RequestMapping(path = "/api/project/{projectId}/pairingBoard", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity<ProjectDTO> addPairingBoard(@PathVariable long projectId, @RequestBody @Valid PairingBoardDTO pairingBoardDTO) {
-        Project savedProject = projectRepository.findOne(projectId);
+        Project savedProject = projectRepository.findById(projectId).orElse(Project.NULL);
 
         savedProject.getPairingBoards().add(new PairingBoard(pairingBoardDTO.getName(), false, new ArrayList<>(), new ArrayList<>()));
 
@@ -139,7 +139,7 @@ public class ProjectController {
     @RequestMapping(path = "/api/project/{projectId}/pairingBoard/{pairingBoardId}", method = RequestMethod.PUT)
     @ResponseBody
     public ResponseEntity<ProjectDTO> updatePairingBoard(@PathVariable long projectId, @PathVariable long pairingBoardId, @RequestBody @Valid PairingBoardDTO pairingBoardDTO) {
-        Project savedProject = projectRepository.findOne(projectId);
+        Project savedProject = projectRepository.findById(projectId).orElse(Project.NULL);
 
         PairingBoard matchingPairingBoard = savedProject.getPairingBoards().stream()
                 .filter(pb -> pb.getId() == pairingBoardId)

--- a/src/main/java/com/parrit/entities/Project.java
+++ b/src/main/java/com/parrit/entities/Project.java
@@ -3,10 +3,14 @@ package com.parrit.entities;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
+import java.util.Collections;
 import java.util.List;
 
+import static com.parrit.repositories.ProjectRepository.PASSWORD_COLUMN_NAME;
+import static com.parrit.repositories.ProjectRepository.TABLE_NAME;
+
 @Entity
-@Table(name = "project",
+@Table(name = TABLE_NAME,
         indexes = {
                 @Index(name = "project_pkey", unique = true, columnList = "id")
         },
@@ -15,6 +19,14 @@ import java.util.List;
         }
 )
 public class Project {
+    public static Project NULL;
+    static {
+        NULL = new Project();
+        NULL.pairingBoards = Collections.emptyList();
+        NULL.people = Collections.emptyList();
+        NULL.name = "";
+        NULL.password = "";
+    }
 
     @Id
     @Column(name = "id", nullable = false)
@@ -26,7 +38,7 @@ public class Project {
     @Column(name = "name", nullable = false, length = 255)
     private String name;
 
-    @Column(name = "password", nullable = false, length = 255)
+    @Column(name = PASSWORD_COLUMN_NAME, nullable = false, length = 255)
     private String password;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
@@ -116,7 +128,7 @@ public class Project {
         return "Project{" +
                 "id=" + id +
                 ", name='" + name + '\'' +
-                ", password='" + password + '\'' +
+                ", password='********'" +
                 ", pairingBoards=" + pairingBoards +
                 ", people=" + people +
                 '}';

--- a/src/main/java/com/parrit/repositories/ProjectPasswordUpdater.java
+++ b/src/main/java/com/parrit/repositories/ProjectPasswordUpdater.java
@@ -1,0 +1,27 @@
+package com.parrit.repositories;
+
+import com.parrit.security.crypto.password.PasswordUpdater;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import static com.parrit.repositories.ProjectRepository.PASSWORD_COLUMN_NAME;
+import static com.parrit.repositories.ProjectRepository.TABLE_NAME;
+
+@Component
+public class ProjectPasswordUpdater implements PasswordUpdater {
+	private final JdbcTemplate jdbcTemplate;
+	private static final String updateProjectPasswordSql =
+		String.format("update %s set %s = ? where %s = ?",
+			TABLE_NAME, PASSWORD_COLUMN_NAME, PASSWORD_COLUMN_NAME);
+
+	@Autowired
+	public ProjectPasswordUpdater(JdbcTemplate jdbcTemplate) {
+		this.jdbcTemplate = jdbcTemplate;
+	}
+
+	@Override
+	public void updateProjectPassword(String oldEncodedPassword, String newEncodedPassword) {
+		jdbcTemplate.update(updateProjectPasswordSql, newEncodedPassword, oldEncodedPassword);
+	}
+}

--- a/src/main/java/com/parrit/repositories/ProjectRepository.java
+++ b/src/main/java/com/parrit/repositories/ProjectRepository.java
@@ -6,7 +6,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProjectRepository extends CrudRepository<Project, Long> {
+    String TABLE_NAME = "project";
+    String PASSWORD_COLUMN_NAME = "password";
 
     Project findByName(String name);
-
 }

--- a/src/main/java/com/parrit/security/crypto/password/PasswordMigrator.java
+++ b/src/main/java/com/parrit/security/crypto/password/PasswordMigrator.java
@@ -1,0 +1,29 @@
+package com.parrit.security.crypto.password;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class PasswordMigrator implements PasswordEncoder {
+	private final PasswordEncoder legacyEncoder;
+	private final PasswordEncoder targetEncoder;
+	private final PasswordUpdater passwordUpdater;
+
+	public PasswordMigrator(PasswordEncoder legacyEncoder, PasswordEncoder targetEncoder, PasswordUpdater passwordUpdater) {
+		this.legacyEncoder = legacyEncoder;
+		this.targetEncoder = targetEncoder;
+		this.passwordUpdater = passwordUpdater;
+	}
+
+	 @Override
+	 public String encode(CharSequence rawPassword) {
+		 return targetEncoder.encode(rawPassword);
+	 }
+
+	 @Override
+	 public boolean matches(CharSequence rawPassword, String encodedPassword) {
+		 boolean matches = legacyEncoder.matches(rawPassword, encodedPassword);
+		 if(matches) {
+			 passwordUpdater.updateProjectPassword(encodedPassword, targetEncoder.encode(rawPassword));
+		 }
+		 return matches;
+	 }
+}

--- a/src/main/java/com/parrit/security/crypto/password/PasswordUpdater.java
+++ b/src/main/java/com/parrit/security/crypto/password/PasswordUpdater.java
@@ -1,0 +1,5 @@
+package com.parrit.security.crypto.password;
+
+public interface PasswordUpdater {
+	void updateProjectPassword(String oldEncodedPassword, String newEncodedPassword);
+}

--- a/src/main/java/com/parrit/security/crypto/password/ShaPasswordEncoder.java
+++ b/src/main/java/com/parrit/security/crypto/password/ShaPasswordEncoder.java
@@ -1,0 +1,18 @@
+package com.parrit.security.crypto.password;
+
+import org.springframework.security.crypto.password.MessageDigestPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class ShaPasswordEncoder implements PasswordEncoder {
+	 private MessageDigestPasswordEncoder legacyEncoder = new MessageDigestPasswordEncoder("SHA-256");
+
+	 @Override
+	 public String encode(CharSequence rawPassword) {
+		  return legacyEncoder.encode(rawPassword);
+	 }
+
+	 @Override
+	 public boolean matches(CharSequence rawPassword, String encodedPassword) {
+		  return legacyEncoder.matches(rawPassword, encodedPassword);
+	 }
+}

--- a/src/main/java/com/parrit/services/PairingService.java
+++ b/src/main/java/com/parrit/services/PairingService.java
@@ -1,9 +1,9 @@
 package com.parrit.services;
 
+import com.parrit.entities.PairingBoard;
 import com.parrit.entities.PairingHistory;
 import com.parrit.entities.Person;
 import com.parrit.entities.Project;
-import com.parrit.entities.PairingBoard;
 import com.parrit.repositories.PairingHistoryRepository;
 import com.parrit.repositories.ProjectRepository;
 import com.parrit.utilities.CurrentTimeProvider;
@@ -36,7 +36,7 @@ public class PairingService {
     public List<PairingHistory> savePairing(long projectId) {
         List<PairingHistory> pairingHistories = new ArrayList<>();
 
-        Project project = projectRepository.findOne(projectId);
+        Project project = projectRepository.findById(projectId).orElse(Project.NULL);
         Timestamp currentTime = currentTimeProvider.getCurrentTime();
 
         for(PairingBoard pairingBoard : project.getPairingBoards()) {
@@ -53,7 +53,7 @@ public class PairingService {
     }
 
     public Project getRecommendation(long projectId) {
-        Project project = projectRepository.findOne(projectId);
+        Project project = projectRepository.findById(projectId).orElse(Project.NULL);
         List<PairingHistory> pairingHistory = pairingHistoryRepository.findByProject(project);
 
         Project recommendedProject = recommendationService.get(project, pairingHistory);
@@ -63,7 +63,7 @@ public class PairingService {
     }
 
     public List<PairingHistory> getSortedPairingHistory(long projectId) {
-        Project project = projectRepository.findOne(projectId);
+        Project project = projectRepository.findById(projectId).orElse(Project.NULL);
         return pairingHistoryRepository.findByProjectOrderByTimestampDesc(project);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
-# Session timeout in seconds (default is 30 minutes)
-server.session.timeout=10800
+server.servlet.session.timeout=3h
 
 spring.jpa.database=POSTGRESQL
 spring.jpa.hibernate.ddl-auto=validate

--- a/src/test/java/com/parrit/controllers/ProjectControllerTest.java
+++ b/src/test/java/com/parrit/controllers/ProjectControllerTest.java
@@ -21,12 +21,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.encoding.PasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Matchers.any;
@@ -94,7 +95,7 @@ public class ProjectControllerTest {
         newProjectDTO.setPassword("bobpass");
 
         when(mockProjectRepository.save(any(Project.class))).thenReturn(persistedProject);
-        when(passwordEncoder.encodePassword("bobpass", null)).thenReturn("encodedBobpass");
+        when(passwordEncoder.encode("bobpass")).thenReturn("encodedBobpass");
 
         mockMvc.perform(post("/api/project")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -222,7 +223,7 @@ public class ProjectControllerTest {
         ProjectDTO updatedProjectDTO = ProjectTransformer.transform(existingProject);
         updatedProjectDTO.setName("Bob");
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(existingProject);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(existingProject));
         when(mockProjectRepository.save(any(Project.class))).thenAnswer(i -> i.getArguments()[0]);
 
         mockMvc.perform(put("/api/project/1")
@@ -234,7 +235,7 @@ public class ProjectControllerTest {
         Project expectedUpdatedProject = new Project("Bob", "henrypass", new ArrayList<>(), new ArrayList<>());
         expectedUpdatedProject.setId(1L);
 
-        verify(mockProjectRepository).findOne(1L);
+        verify(mockProjectRepository).findById(1L);
         verify(mockProjectRepository).save(eq(expectedUpdatedProject));
     }
 
@@ -247,7 +248,7 @@ public class ProjectControllerTest {
 
         PersonDTO personDTO = PersonTransformer.transform(newPerson);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(existingProject);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(existingProject));
         when(mockProjectRepository.save(any(Project.class))).thenAnswer(i -> i.getArguments()[0]);
 
         Project expectedUpdatedProject = new Project("Henry", "henrypass", new ArrayList<>(), Collections.singletonList(newPerson));
@@ -261,7 +262,7 @@ public class ProjectControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(objectMapper.writeValueAsString(updatedProjectDTO)));
 
-        verify(mockProjectRepository).findOne(1L);
+        verify(mockProjectRepository).findById(1L);
         verify(mockProjectRepository).save(expectedUpdatedProject);
     }
 
@@ -313,7 +314,7 @@ public class ProjectControllerTest {
 
         PairingBoardDTO pairingBoardDTO = PairingBoardTransformer.transform(newPairingBoard);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(existingProject);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(existingProject));
         when(mockProjectRepository.save(any(Project.class))).thenAnswer(i -> i.getArguments()[0]);
 
         Project expectedUpdatedProject = new Project("Henry", "henrypass", Collections.singletonList(newPairingBoard), new ArrayList<>());
@@ -327,7 +328,7 @@ public class ProjectControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(objectMapper.writeValueAsString(updatedProjectDTO)));
 
-        verify(mockProjectRepository).findOne(1L);
+        verify(mockProjectRepository).findById(1L);
         verify(mockProjectRepository).save(expectedUpdatedProject);
     }
 
@@ -356,7 +357,7 @@ public class ProjectControllerTest {
 
         RoleDTO roleDTO = RoleTransformer.transform(newRole);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(existingProject);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(existingProject));
         when(mockProjectRepository.save(any(Project.class))).thenAnswer(i -> i.getArguments()[0]);
 
         PairingBoard expectedPairingBoard = new PairingBoard("Cool Kids", false, new ArrayList<>(), Collections.singletonList(newRole));
@@ -373,7 +374,7 @@ public class ProjectControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(objectMapper.writeValueAsString(updatedProjectDTO)));
 
-        verify(mockProjectRepository).findOne(1L);
+        verify(mockProjectRepository).findById(1L);
         verify(mockProjectRepository).save(expectedUpdatedProject);
     }
 
@@ -429,7 +430,7 @@ public class ProjectControllerTest {
 
         PairingBoardDTO updatedPairingBoardDTO = PairingBoardTransformer.transform(updatedPairingBoard);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(existingProject);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(existingProject));
         when(mockProjectRepository.save(any(Project.class))).thenAnswer(i -> i.getArguments()[0]);
 
         Project expectedUpdatedProject = new Project("Henry", "henrypass", Collections.singletonList(updatedPairingBoard), new ArrayList<>());
@@ -443,7 +444,7 @@ public class ProjectControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(objectMapper.writeValueAsString(updatedProjectDTO)));
 
-        verify(mockProjectRepository).findOne(1L);
+        verify(mockProjectRepository).findById(1L);
         verify(mockProjectRepository).save(expectedUpdatedProject);
     }
 
@@ -484,7 +485,7 @@ public class ProjectControllerTest {
         PairingBoardDTO updatedPairingBoardDTO = new PairingBoardDTO();
         updatedPairingBoardDTO.setName("someName");
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(existingProject);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(existingProject));
 
         mockMvc.perform(put("/api/project/1/pairingBoard/2")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -493,6 +494,6 @@ public class ProjectControllerTest {
                 .andExpect(jsonPath("$.message", equalTo(null)))
                 .andExpect(jsonPath("$.fieldErrors.id", equalTo("Keeaa!? That pairing board doesn't seem to exist.")));
 
-        verify(mockProjectRepository).findOne(1L);
+        verify(mockProjectRepository).findById(1L);
     }
 }

--- a/src/test/java/com/parrit/security/crypto/password/PasswordMigratorTest.java
+++ b/src/test/java/com/parrit/security/crypto/password/PasswordMigratorTest.java
@@ -1,0 +1,66 @@
+package com.parrit.security.crypto.password;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+// grouped stubbing is more readable in this case; don't error on unnecessary stubbing.
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class PasswordMigratorTest {
+	private PasswordMigrator subject;
+	@Mock
+	private PasswordEncoder legacyEncoder;
+	@Mock
+	private PasswordEncoder targetEncoder;
+	@Mock
+	private PasswordUpdater passwordUpdater;
+
+	private String rawPassword = "rawPassword";
+	private String legacyEncodedPassword = "legacyEncodedPassword";
+	private String targetEncodedPassword = "targetEncodedPassword";
+	private String someOtherPasswordLegacyEncoded = "someOtherPasswordLegacyEncoded";
+
+	@Before
+	public void setUp() {
+		when(legacyEncoder.encode(rawPassword)).thenReturn(legacyEncodedPassword);
+		when(legacyEncoder.matches(rawPassword, legacyEncodedPassword)).thenReturn(true);
+		when(targetEncoder.encode(rawPassword)).thenReturn(targetEncodedPassword);
+		when(targetEncoder.matches(rawPassword, targetEncodedPassword)).thenReturn(true);
+		subject = new PasswordMigrator(legacyEncoder, targetEncoder, passwordUpdater);
+	}
+
+	@Test
+	public void encode_returnsPasswordEncodedWithTargetEncoder() {
+		assertThat(subject.encode(rawPassword)).isEqualTo(targetEncodedPassword);
+	}
+
+	@Test
+	public void matches_whenLegacyEncoderSaysPasswordsMatch_returnsTrue() {
+		assertThat(subject.matches(rawPassword, legacyEncodedPassword)).isTrue();
+	}
+
+	@Test
+	public void matches_whenLegacyEncoderSaysPasswordsMatch_encodesRawPasswordWithTargetEncoder_andUpdatesStoredPassword() {
+		subject.matches(rawPassword, legacyEncodedPassword);
+		verify(targetEncoder).encode(rawPassword);
+		verify(passwordUpdater).updateProjectPassword(legacyEncodedPassword, targetEncodedPassword);
+	}
+
+	@Test
+	public void matches_whenLegacyEncoderSaysPasswordsDoNotMatch_returnsFalse() {
+		assertThat(subject.matches(rawPassword, someOtherPasswordLegacyEncoded)).isFalse();
+	}
+
+	@Test
+	public void matches_whenLegacyEncoderSaysPasswordsDoNotMatch_doesNotUpdateStoredPassword() {
+		subject.matches(rawPassword, someOtherPasswordLegacyEncoded);
+		verify(passwordUpdater, never()).updateProjectPassword(anyString(), anyString());
+	}
+}

--- a/src/test/java/com/parrit/services/PairingServiceTest.java
+++ b/src/test/java/com/parrit/services/PairingServiceTest.java
@@ -14,14 +14,12 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -66,14 +64,14 @@ public class PairingServiceTest {
 
         PairingHistory expectedPairingHistory = new PairingHistory(project, "The Pairing Board", Arrays.asList(p1, p2), currentTime);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(project);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
         when(mockPairingHistoryRepository.save(expectedPairingHistory)).thenReturn(expectedPairingHistory);
 
         List<PairingHistory> result = pairingService.savePairing(7L);
 
         assertThat(result, equalTo(Collections.singletonList(expectedPairingHistory)));
 
-        verify(mockProjectRepository).findOne(7L);
+        verify(mockProjectRepository).findById(7L);
         verify(mockPairingHistoryRepository).save(eq(expectedPairingHistory));
         verify(mockCurrentTimeProvider, times(1)).getCurrentTime();
     }
@@ -101,7 +99,7 @@ public class PairingServiceTest {
         PairingHistory expectedPairingHistory1 = new PairingHistory(project, "The Pairing Board", Arrays.asList(p1, p2), currentTime);
         PairingHistory expectedPairingHistory2 = new PairingHistory(project, "The Second Pairing Board", Arrays.asList(p3, p4), currentTime);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(project);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
         when(mockPairingHistoryRepository.save(expectedPairingHistory1)).thenReturn(expectedPairingHistory1);
         when(mockPairingHistoryRepository.save(expectedPairingHistory2)).thenReturn(expectedPairingHistory2);
 
@@ -109,7 +107,7 @@ public class PairingServiceTest {
 
         assertThat(result, equalTo(Arrays.asList(expectedPairingHistory1, expectedPairingHistory2)));
 
-        verify(mockProjectRepository).findOne(7L);
+        verify(mockProjectRepository).findById(7L);
         verify(mockPairingHistoryRepository).save(eq(expectedPairingHistory1));
         verify(mockPairingHistoryRepository).save(eq(expectedPairingHistory2));
         verify(mockCurrentTimeProvider, times(1)).getCurrentTime();
@@ -133,14 +131,14 @@ public class PairingServiceTest {
 
         PairingHistory expectedPairingHistory = new PairingHistory(project, "The Pairing Board", Arrays.asList(p1, p2, p3), currentTime);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(project);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
         when(mockPairingHistoryRepository.save(expectedPairingHistory)).thenReturn(expectedPairingHistory);
 
         List<PairingHistory> result = pairingService.savePairing(7L);
 
         assertThat(result, equalTo(Collections.singletonList(expectedPairingHistory)));
 
-        verify(mockProjectRepository).findOne(7L);
+        verify(mockProjectRepository).findById(7L);
         verify(mockPairingHistoryRepository).save(eq(expectedPairingHistory));
         verify(mockCurrentTimeProvider, times(1)).getCurrentTime();
     }
@@ -159,14 +157,14 @@ public class PairingServiceTest {
 
         PairingHistory expectedPairingHistory = new PairingHistory(project,  "The Pairing Board", Collections.singletonList(p1), currentTime);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(project);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
         when(mockPairingHistoryRepository.save(expectedPairingHistory)).thenReturn(expectedPairingHistory);
 
         List<PairingHistory> result = pairingService.savePairing(7L);
 
         assertThat(result, equalTo(Collections.singletonList(expectedPairingHistory)));
 
-        verify(mockProjectRepository).findOne(7L);
+        verify(mockProjectRepository).findById(7L);
         verify(mockPairingHistoryRepository).save(eq(expectedPairingHistory));
         verify(mockCurrentTimeProvider, times(1)).getCurrentTime();
     }
@@ -180,12 +178,12 @@ public class PairingServiceTest {
 
         Project project = new Project("One", "onepass", pairingBoards, new ArrayList<>());
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(project);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
 
         List<PairingHistory> result = pairingService.savePairing(7L);
         assertThat(result, equalTo(Collections.emptyList()));
 
-        verify(mockProjectRepository).findOne(7L);
+        verify(mockProjectRepository).findById(7L);
         verifyZeroInteractions(mockPairingHistoryRepository);
         verify(mockCurrentTimeProvider, times(1)).getCurrentTime();
     }
@@ -196,12 +194,12 @@ public class PairingServiceTest {
         PairingHistory pairingHistory = new PairingHistory();
         List<PairingHistory> pairingHistories = Collections.singletonList(pairingHistory);
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(project);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
         when(mockPairingHistoryRepository.findByProject(any(Project.class))).thenReturn(pairingHistories);
 
         pairingService.getRecommendation(77L);
 
-        verify(mockProjectRepository).findOne(77L);
+        verify(mockProjectRepository).findById(77L);
         verify(mockPairingHistoryRepository).findByProject(project);
         verify(mockRecommendationService).get(project, pairingHistories);
     }
@@ -214,7 +212,7 @@ public class PairingServiceTest {
 
         Project recommendedProject = new Project("One", "onepass", new ArrayList<>(), new ArrayList<>());
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(project);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
         when(mockPairingHistoryRepository.findByProject(any(Project.class))).thenReturn(pairingHistories);
         when(mockRecommendationService.get(any(Project.class), anyListOf(PairingHistory.class))).thenReturn(recommendedProject);
 
@@ -234,14 +232,14 @@ public class PairingServiceTest {
             new PairingHistory(project, "Pairing Board 2", new ArrayList<>(), new Timestamp(50))
         );
 
-        when(mockProjectRepository.findOne(anyLong())).thenReturn(project);
+        when(mockProjectRepository.findById(anyLong())).thenReturn(Optional.of(project));
         when(mockPairingHistoryRepository.findByProjectOrderByTimestampDesc(any(Project.class))).thenReturn(pairingHistories);
 
         List<PairingHistory> result = pairingService.getSortedPairingHistory(7L);
 
         assertThat(result, equalTo(pairingHistories));
 
-        verify(mockProjectRepository).findOne(7L);
+        verify(mockProjectRepository).findById(7L);
         verify(mockPairingHistoryRepository).findByProjectOrderByTimestampDesc(project);
     }
 }


### PR DESCRIPTION
- Spring Security 5 removed ShaPasswordEncoder + strong one-way hash
  recommended over message digest algorithms
  => use the provided DelegatingPasswordEncoder plus custom code
     (see c.p.security.crypto.password) to migrate passwords from
     SHA-256 to BCrypt.

- Upgrade Flyway from 3.x to 5.x => checksums change
  => include SQL required to update checksums.  This script must be
     run before deploying to avoid Flyway complaining that checksum
     fails.

- JPA Repositories: from #findOne to #findById and return value is
  wrapped in an Optional.
  ==> Introduce Null Object for Project, resolving to that value if
      desired project not found.

- property `server.session.timeout` is now
  `server.servlet.session.timeout`