### PR TITLE
Only return pair rotation history from the last 30 days.

### DIFF
--- a/frontend/src/project/components/PairingHistory.tsx
+++ b/frontend/src/project/components/PairingHistory.tsx
@@ -6,7 +6,7 @@ import { PairingHistoryRecordList } from "./PairingHistoryRecordList";
 import { AppContext } from "./App";
 import { ProjectContext } from "../ProjectContext";
 
-export const PairingHistory: React.FC = (props) => {
+export const PairingHistory: React.FC = () => {
   const { pairingHistory } = useContext(ProjectContext);
 
   const { pairingHistoryOpen, setPairingHistoryOpen } = useContext(AppContext);
@@ -30,7 +30,10 @@ export const PairingHistory: React.FC = (props) => {
       <Scrollbars>
         <div className="inner-pairing-history-wrapper">
           <div className="header">
-            <h2>Pair Rotation History</h2>
+            <div className="header-text">
+                <h2>Pair Rotation History</h2>
+                <h3>History is stored for 30 days.</h3>
+            </div>
             <div
               className="cancel"
               onClick={closePairingHistoryPanel.bind(this)}

--- a/frontend/styles/sass/pairing-history.scss
+++ b/frontend/styles/sass/pairing-history.scss
@@ -28,9 +28,12 @@
     margin-top: 26px;
     margin-bottom: 38px;
 
-    h2 {
-      color: $silver;
+    .header-text {
       display: inline-block;
+
+      h2 {
+        color: $silver;
+      }
     }
 
     .cancel {
@@ -51,7 +54,7 @@
   .body {
     margin-bottom: 28px;
   }
-  
+
   .no-history {
     .clock {
       background-image: url("./images/history.svg");

--- a/src/main/java/com/parrit/repositories/PairingHistoryRepository.java
+++ b/src/main/java/com/parrit/repositories/PairingHistoryRepository.java
@@ -13,6 +13,4 @@ public interface PairingHistoryRepository extends JpaRepository<PairingHistory, 
 
     List<PairingHistory> findByProjectAndTimestampAfter(Project project, Timestamp timestamp);
 
-    List<PairingHistory> findByProjectOrderByTimestampDesc(Project project);
-
 }

--- a/src/main/java/com/parrit/repositories/PairingHistoryRepository.java
+++ b/src/main/java/com/parrit/repositories/PairingHistoryRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Repository
 public interface PairingHistoryRepository extends JpaRepository<PairingHistory, Long> {
 
-    List<PairingHistory> findByProjectAndTimestampAfter(Project project, Timestamp timestamp);
+    List<PairingHistory> findByProjectAndTimestampAfterOrderByTimestampDesc(Project project, Timestamp timestamp);
 
 }

--- a/src/main/java/com/parrit/services/PairingService.java
+++ b/src/main/java/com/parrit/services/PairingService.java
@@ -43,13 +43,13 @@ public class PairingService {
     public Project getRecommendation(Project project) {
         Timestamp currentTime = currentTimeProvider.getCurrentTime();
         Timestamp thirtyDaysAgo = new Timestamp(currentTime.getTime() - ONE_MONTH_IN_MILLISECONDS);
-        List<PairingHistory> pairingHistory = pairingHistoryRepository.findByProjectAndTimestampAfter(project, thirtyDaysAgo);
+        List<PairingHistory> pairingHistory = pairingHistoryRepository.findByProjectAndTimestampAfterOrderByTimestampDesc(project, thirtyDaysAgo);
         return recommendationService.get(project, pairingHistory);
     }
 
     public List<PairingHistory> getSortedPairingHistory(Project project) {
         Timestamp currentTime = currentTimeProvider.getCurrentTime();
         Timestamp thirtyDaysAgo = new Timestamp(currentTime.getTime() - ONE_MONTH_IN_MILLISECONDS);
-        return pairingHistoryRepository.findByProjectAndTimestampAfter(project, thirtyDaysAgo);
+        return pairingHistoryRepository.findByProjectAndTimestampAfterOrderByTimestampDesc(project, thirtyDaysAgo);
     }
 }

--- a/src/main/java/com/parrit/services/PairingService.java
+++ b/src/main/java/com/parrit/services/PairingService.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 @Service
 public class PairingService {
 
-    private static final long TWO_MONTHS_IN_MILLISECONDS = 5259486000L;
+    private static final long ONE_MONTH_IN_MILLISECONDS = 30 * 24 * 60 * 60 * 1000L;
 
     private final PairingHistoryRepository pairingHistoryRepository;
     private final RecommendationService recommendationService;
@@ -42,12 +42,14 @@ public class PairingService {
 
     public Project getRecommendation(Project project) {
         Timestamp currentTime = currentTimeProvider.getCurrentTime();
-        Timestamp twoMonthsAgo = new Timestamp(currentTime.getTime() - TWO_MONTHS_IN_MILLISECONDS);
-        List<PairingHistory> pairingHistory = pairingHistoryRepository.findByProjectAndTimestampAfter(project, twoMonthsAgo);
+        Timestamp thirtyDaysAgo = new Timestamp(currentTime.getTime() - ONE_MONTH_IN_MILLISECONDS);
+        List<PairingHistory> pairingHistory = pairingHistoryRepository.findByProjectAndTimestampAfter(project, thirtyDaysAgo);
         return recommendationService.get(project, pairingHistory);
     }
 
     public List<PairingHistory> getSortedPairingHistory(Project project) {
-        return pairingHistoryRepository.findByProjectOrderByTimestampDesc(project);
+        Timestamp currentTime = currentTimeProvider.getCurrentTime();
+        Timestamp thirtyDaysAgo = new Timestamp(currentTime.getTime() - ONE_MONTH_IN_MILLISECONDS);
+        return pairingHistoryRepository.findByProjectAndTimestampAfter(project, thirtyDaysAgo);
     }
 }

--- a/src/main/java/com/parrit/services/RecommendationService.java
+++ b/src/main/java/com/parrit/services/RecommendationService.java
@@ -26,7 +26,7 @@ public class RecommendationService {
             Map<Person, Person> bestPairingMap = recHelper.getBestPairingMap();
             for (Person floatingPerson : bestPairingMap.keySet()) {
                 Person personToPairWith = bestPairingMap.get(floatingPerson);
-                PairingBoard pairPairingBoard = recHelper.getPairingBoardForAvailabelPerson(personToPairWith);
+                PairingBoard pairPairingBoard = recHelper.getPairingBoardForAvailablePerson(personToPairWith);
 
                 /*
                  * Pairing two Floating People in an empty pairing board
@@ -88,7 +88,7 @@ public class RecommendationService {
 
         recHelper.putFloatingPersonBack(currentFloatingPerson);
 
-        if(recHelper.canExcludeMySelf(currentFloatingPerson)) {
+        if(recHelper.canExcludeMySelf()) {
             recHelper.excludeFloatingPerson(currentFloatingPerson);
             findBestPairing(recHelper);
             recHelper.includeFloatingPerson(currentFloatingPerson);
@@ -304,7 +304,7 @@ public class RecommendationService {
             }
         }
 
-        public boolean canExcludeMySelf(Person currentFloatingPerson) {
+        public boolean canExcludeMySelf() {
             /*
              * No one has been excluded yet
              *   AND
@@ -331,7 +331,7 @@ public class RecommendationService {
             return bestPairingMap;
         }
 
-        public PairingBoard getPairingBoardForAvailabelPerson(Person personToPairWith) {
+        public PairingBoard getPairingBoardForAvailablePerson(Person personToPairWith) {
             return availablePersonToPairingBoardMap.get(personToPairWith);
         }
 

--- a/src/test/java/com/parrit/services/PairingServiceTest.java
+++ b/src/test/java/com/parrit/services/PairingServiceTest.java
@@ -39,7 +39,7 @@ public class PairingServiceTest {
     @Mock
     private CurrentTimeProvider mockCurrentTimeProvider;
 
-    private Timestamp currentTime = new Timestamp(1456364985548L);
+    private final Timestamp currentTime = new Timestamp(1456364985548L);
 
     @Before
     public void setup() {
@@ -204,15 +204,17 @@ public class PairingServiceTest {
         Project recommendedProject = new Project("One", "onepass", new ArrayList<>(), new ArrayList<>());
 
         when(mockPairingHistoryRepository.findByProjectAndTimestampAfter(any(Project.class), any(Timestamp.class))).thenReturn(pairingHistories);
+        Timestamp mockNow = Timestamp.valueOf("2020-06-30 00:00:00.000000000");
+        when(mockCurrentTimeProvider.getCurrentTime()).thenReturn(mockNow);
         when(mockRecommendationService.get(any(Project.class), anyList())).thenReturn(recommendedProject);
 
         Project returnedProject = pairingService.getRecommendation(project);
 
         assertThat(returnedProject, equalTo(recommendedProject));
 
-        Timestamp twoMonthsAgoTime = new Timestamp(1451105499548L);
+        Timestamp thirtyDaysAgo = Timestamp.valueOf("2020-05-31 00:00:00.000000000");
 
-        verify(mockPairingHistoryRepository).findByProjectAndTimestampAfter(project, twoMonthsAgoTime);
+        verify(mockPairingHistoryRepository).findByProjectAndTimestampAfter(project, thirtyDaysAgo);
         verify(mockRecommendationService).get(project, pairingHistories);
     }
 
@@ -225,12 +227,15 @@ public class PairingServiceTest {
                 new PairingHistory(project, "Pairing Board 2", new ArrayList<>(), new Timestamp(50))
         );
 
-        when(mockPairingHistoryRepository.findByProjectOrderByTimestampDesc(any(Project.class))).thenReturn(pairingHistories);
+        when(mockPairingHistoryRepository.findByProjectAndTimestampAfter(any(Project.class), any(Timestamp.class))).thenReturn(pairingHistories);
+        Timestamp mockNow = Timestamp.valueOf("2020-06-30 00:00:00.000000000");
+        when(mockCurrentTimeProvider.getCurrentTime()).thenReturn(mockNow);
 
         List<PairingHistory> result = pairingService.getSortedPairingHistory(project);
 
         assertThat(result, equalTo(pairingHistories));
 
-        verify(mockPairingHistoryRepository).findByProjectOrderByTimestampDesc(project);
+        Timestamp thirtyDaysAgo = Timestamp.valueOf("2020-05-31 00:00:00.000000000");
+        verify(mockPairingHistoryRepository).findByProjectAndTimestampAfter(project, thirtyDaysAgo);
     }
 }

--- a/src/test/java/com/parrit/services/PairingServiceTest.java
+++ b/src/test/java/com/parrit/services/PairingServiceTest.java
@@ -203,7 +203,7 @@ public class PairingServiceTest {
 
         Project recommendedProject = new Project("One", "onepass", new ArrayList<>(), new ArrayList<>());
 
-        when(mockPairingHistoryRepository.findByProjectAndTimestampAfter(any(Project.class), any(Timestamp.class))).thenReturn(pairingHistories);
+        when(mockPairingHistoryRepository.findByProjectAndTimestampAfterOrderByTimestampDesc(any(Project.class), any(Timestamp.class))).thenReturn(pairingHistories);
         Timestamp mockNow = Timestamp.valueOf("2020-06-30 00:00:00.000000000");
         when(mockCurrentTimeProvider.getCurrentTime()).thenReturn(mockNow);
         when(mockRecommendationService.get(any(Project.class), anyList())).thenReturn(recommendedProject);
@@ -214,7 +214,7 @@ public class PairingServiceTest {
 
         Timestamp thirtyDaysAgo = Timestamp.valueOf("2020-05-31 00:00:00.000000000");
 
-        verify(mockPairingHistoryRepository).findByProjectAndTimestampAfter(project, thirtyDaysAgo);
+        verify(mockPairingHistoryRepository).findByProjectAndTimestampAfterOrderByTimestampDesc(project, thirtyDaysAgo);
         verify(mockRecommendationService).get(project, pairingHistories);
     }
 
@@ -227,7 +227,7 @@ public class PairingServiceTest {
                 new PairingHistory(project, "Pairing Board 2", new ArrayList<>(), new Timestamp(50))
         );
 
-        when(mockPairingHistoryRepository.findByProjectAndTimestampAfter(any(Project.class), any(Timestamp.class))).thenReturn(pairingHistories);
+        when(mockPairingHistoryRepository.findByProjectAndTimestampAfterOrderByTimestampDesc(any(Project.class), any(Timestamp.class))).thenReturn(pairingHistories);
         Timestamp mockNow = Timestamp.valueOf("2020-06-30 00:00:00.000000000");
         when(mockCurrentTimeProvider.getCurrentTime()).thenReturn(mockNow);
 
@@ -236,6 +236,6 @@ public class PairingServiceTest {
         assertThat(result, equalTo(pairingHistories));
 
         Timestamp thirtyDaysAgo = Timestamp.valueOf("2020-05-31 00:00:00.000000000");
-        verify(mockPairingHistoryRepository).findByProjectAndTimestampAfter(project, thirtyDaysAgo);
+        verify(mockPairingHistoryRepository).findByProjectAndTimestampAfterOrderByTimestampDesc(project, thirtyDaysAgo);
     }
 }


### PR DESCRIPTION
Only return pair rotation history from the last 30 days.
Only recommend pairs based on history from the last 30 days.

+ changed the way we calculated timestamp to represent exactly 30 days

[#176018739]